### PR TITLE
3.0.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,48 @@
+project('hinnant-date', ['cpp'],
+        default_options: ['cpp_std=c++17'],
+        license: 'MIT')
+
+pkg = import('pkgconfig')
+
+thread_dep = dependency('threads')
+
+header_files = files(
+  'include/date/chrono_io.h',
+  'include/date/date.h',
+  'include/date/ios.h',
+  'include/date/islamic.h',
+  'include/date/iso_week.h',
+  'include/date/julian.h',
+  'include/date/tz.h',
+  'include/date/tz_private.h'
+)
+defines = []
+public_defines = []
+deps = [thread_dep]
+if get_option('use_system_tzdb')
+  defines += ['-DUSE_AUTOLOAD=0', '-DHAS_REMOTE_API=0']
+  public_defines += ['-DUSE_OS_TZDB=1']
+else
+  defines += ['-DUSE_AUTOLOAD=1', '-DHAS_REMOTE_API=1']
+  public_defines += ['-DUSE_OS_TZDB=0']
+  deps += dependency('libcurl')
+endif
+
+if get_option('use_tzdb_in_dot')
+  defines += ['-DINSTALL=.']
+endif
+
+i = include_directories('include')
+tz_lib = library('tz', 'src/tz.cpp',
+     include_directories: i,
+     cpp_args: defines + public_defines,
+     dependencies: deps)
+
+tz_dep = declare_dependency(
+  compile_args: public_defines,
+  include_directories: i,
+  link_with: tz_lib
+)
+date_dep = declare_dependency(
+  include_directories: i
+)

--- a/meson.build
+++ b/meson.build
@@ -13,19 +13,33 @@ header_files = files(
   'include/date/islamic.h',
   'include/date/iso_week.h',
   'include/date/julian.h',
+  'include/date/ptz.h',
+  'include/date/solar_hijri.h',
   'include/date/tz.h',
   'include/date/tz_private.h'
 )
 defines = []
-public_defines = []
-deps = [thread_dep]
-if get_option('use_system_tzdb')
-  defines += ['-DUSE_AUTOLOAD=0', '-DHAS_REMOTE_API=0']
-  public_defines += ['-DUSE_OS_TZDB=1']
+date_public_defines = []
+tz_public_defines = []
+tz_deps = [thread_dep]
+
+if get_option('only_c_locale')
+  date_public_defines += ['-DONLY_C_LOCALE=1']
+endif
+
+if not get_option('string_view')
+  date_public_defines += ['-DHAS_STRING_VIEW=0']
+endif
+
+if get_option('use_manual_tzdb')
+  defines += ['-DAUTO_DOWNLOAD=0', '-DHAS_REMOTE_API=0']
+elif get_option('use_system_tzdb')
+  defines += ['-DAUTO_DOWNLOAD=0', '-DHAS_REMOTE_API=0']
+  tz_public_defines += ['-DUSE_OS_TZDB=1']
 else
-  defines += ['-DUSE_AUTOLOAD=1', '-DHAS_REMOTE_API=1']
-  public_defines += ['-DUSE_OS_TZDB=0']
-  deps += dependency('libcurl')
+  defines += ['-DAUTO_DOWNLOAD=1', '-DHAS_REMOTE_API=1']
+  tz_public_defines += ['-DUSE_OS_TZDB=0']
+  tz_deps += dependency('libcurl')
 endif
 
 if get_option('use_tzdb_in_dot')
@@ -34,15 +48,16 @@ endif
 
 i = include_directories('include')
 tz_lib = library('tz', 'src/tz.cpp',
-     include_directories: i,
-     cpp_args: defines + public_defines,
-     dependencies: deps)
-
+  include_directories: i,
+  cpp_args: defines + date_public_defines + tz_public_defines,
+  dependencies: tz_deps
+)
 tz_dep = declare_dependency(
-  compile_args: public_defines,
+  compile_args: date_public_defines + tz_public_defines,
   include_directories: i,
   link_with: tz_lib
 )
 date_dep = declare_dependency(
+  compile_args: date_public_defines,
   include_directories: i
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,4 +2,13 @@ option('use_system_tzdb', type: 'boolean', value: false,
        description: 'Use the operating system\'s timezone database')
 
 option('use_tzdb_in_dot', type: 'boolean', value: false,
-       description: 'Save the timezone database init the current folder')
+       description: 'Save the timezone database in the current folder')
+
+option('use_manual_tzdb', type: 'boolean', value: false,
+       description: 'User will set TZ DB manually by invoking set_install in their code')
+
+option('only_c_locale', type: 'boolean', value: false,
+       description: 'Use built-in date and time formatting facets (implemented only for C locale)')
+
+option('string_view', type: 'boolean', value: true,
+       description: 'Use string_view on compilers with C++17 support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('use_system_tzdb', type: 'boolean', value: false,
+       description: 'Use the operating system\'s timezone database')
+
+option('use_tzdb_in_dot', type: 'boolean', value: false,
+       description: 'Save the timezone database init the current folder')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-source_url=https://github.com/HowardHinnant/date/archive/v2.4.1.tar.gz
-source_filename=date-2.4.1.tar.gz
-source_hash=98907d243397483bd7ad889bf6c66746db0d7d2a39cc9aacc041834c40b65b98
-directory=date-2.4.1
+source_url=https://github.com/HowardHinnant/date/archive/v3.0.0.tar.gz
+source_filename=date-3.0.0.tar.gz
+source_hash=87bba2eaf0ebc7ec539e5e62fc317cb80671a337c1fb1b84cb9e4d42c6dbebe3
+directory=date-3.0.0

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+source_url=https://github.com/HowardHinnant/date/archive/v2.4.1.tar.gz
+source_filename=date-2.4.1.tar.gz
+source_hash=98907d243397483bd7ad889bf6c66746db0d7d2a39cc9aacc041834c40b65b98
+directory=date-2.4.1


### PR DESCRIPTION
3.0.0 release files + new build options from upstream cmake.

I'd really love to replace use_x flags with `option('tzdb', choices: ['system', 'manual', 'download']...` since the flags are mutually exclusive. But that would break backward compatibility with 2.4.1 wrap files :(